### PR TITLE
Disable tailwindcss's global styles

### DIFF
--- a/components/source-preview.tsx
+++ b/components/source-preview.tsx
@@ -123,7 +123,7 @@ export default function SourcePreview(props: Props) {
   let lineNumberWidth = lines.length.toString(10).length + 1;
   let lastMappingColor = 0;
   return (
-    <div className="w-full h-full flex flex-col">
+    <div className="w-full h-full flex flex-col font-mono text-sm">
       {renderableMappings.map((m, i) => {
         return (
           <React.Fragment key={`line-${i}`}>

--- a/components/visualizer.tsx
+++ b/components/visualizer.tsx
@@ -13,10 +13,11 @@ export default function Visualizer({ sourcemapContent }: Props) {
     let selectedSourceMap = sourcemapContent[selectedSourceMapIndex];
 
     return (
-      <div className="h-screen">
+      <div id="sourcemap-visualizer" className="h-screen font-sans leading-normal">
         <div className="bg-gray-700 p-2 flex">
           <div className="text-white mr-4">Select Bundle</div>
           <select
+            className="border-none"
             onChange={(e) => {
               setSelectedSourceMapIndex(parseInt(e.target.value, 10));
             }}

--- a/style.css
+++ b/style.css
@@ -1,3 +1,14 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Parts of preflight that are actually needed: */
+#sourcemap-visualizer *,
+#sourcemap-visualizer ::before,
+#sourcemap-visualizer ::after {
+  box-sizing: border-box;
+}
+
+#sourcemap-visualizer select {
+	font-size: 100%;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,6 +2,9 @@ module.exports = {
   theme: {
     extend: {},
   },
+  corePlugins: {
+    preflight: false,
+  },
   variants: {},
   plugins: [],
-}
+};

--- a/website/app.tsx
+++ b/website/app.tsx
@@ -29,7 +29,7 @@ export default function App() {
     return <Visualizer sourcemapContent={sourcemapContent} />;
   } else {
     return (
-      <div className="max-w-xl mx-auto p-16">
+      <div className="max-w-xl mx-auto p-16 font-sans leading-normal">
         <div className="font-medium text-lg text-gray-700">
           Upload your <span className="underline">sourcemap-info.json</span> to
           get started

--- a/website/index.html
+++ b/website/index.html
@@ -6,7 +6,7 @@
     <title>Parcel sourcemap visualiser</title>
     <link rel="stylesheet" href="~/style.css" />
   </head>
-  <body>
+  <body class="m-0">
     <div id="app"></div>
 
     <script src="./index.tsx"></script>


### PR DESCRIPTION
By default, Tailwindcss removes all borders (e.g. from selects), so when including the component in the REPL, all `<select>` borders were gone: https://tailwindcss.com/docs/preflight/#app. I've disabled that feature and added the necessary classes to retain the previous look.

I've also found that a monospace font for the source view is easier to read (the second commit), what do you think?

![localhost_1234_](https://user-images.githubusercontent.com/4586894/79362326-c05d4e00-7f46-11ea-926f-4831546b6f51.png)

